### PR TITLE
Dispatcher more agnostic to dispatch calls

### DIFF
--- a/packages/dispatcher/lib/dispatcher.js
+++ b/packages/dispatcher/lib/dispatcher.js
@@ -45,7 +45,8 @@ MeteorFlux.Dispatcher = function(){
 * @param {function} callback
 * @return {string}
 */
-MeteorFlux.Dispatcher.prototype.register = function(callback) {
+MeteorFlux.Dispatcher.prototype.register = function(/* arguments */) {
+  var callback = this._curateCallback.apply(this, arguments);
   var id = _prefix + _lastID++;
   this._callbacks[id] = callback;
   return id;
@@ -173,6 +174,25 @@ MeteorFlux.Dispatcher.prototype._startDispatching = function(/* arguments */) {
 MeteorFlux.Dispatcher.prototype._stopDispatching = function() {
   this._pendingPayload = null;
   this._isDispatching = false;
+};
+
+/**
+ * Curate the payload. If the user uses the first argument as string, use it
+ * as action type and include it in the payload.
+ *
+ * @internal
+ */
+MeteorFlux.Dispatcher.prototype._curateCallback = function(/* arguments */) {
+  if (typeof arguments[0] === 'string') {
+    var type = arguments[0];
+    var func = arguments[1];
+    return function(action) {
+      if (action.type === type)
+        func(action);
+    };
+  } else {
+    return arguments[0];
+  }
 };
 
 

--- a/packages/dispatcher/lib/dispatcher.js
+++ b/packages/dispatcher/lib/dispatcher.js
@@ -45,8 +45,7 @@ MeteorFlux.Dispatcher = function(){
 * @param {function} callback
 * @return {string}
 */
-MeteorFlux.Dispatcher.prototype.register = function(/* arguments */) {
-  var callback = this._curateCallback.apply(this, arguments);
+MeteorFlux.Dispatcher.prototype.register = function(callback) {
   var id = _prefix + _lastID++;
   this._callbacks[id] = callback;
   return id;
@@ -113,8 +112,7 @@ MeteorFlux.Dispatcher.prototype.dispatch = function(/* arguments */) {
     'dispatcher-cant-dispatch-while-dispatching',
     'Dispatch.dispatch(...): Cannot dispatch in the middle of a dispatch.'
   );
-  var payload = this._curatePayload.apply(this, arguments);
-  this._startDispatching(payload);
+  this._startDispatching.apply(this, arguments);
   try {
     for (var id in this._callbacks) {
       if (this._isPending[id]) {
@@ -145,22 +143,25 @@ MeteorFlux.Dispatcher.prototype.isDispatching = function() {
 */
 MeteorFlux.Dispatcher.prototype._invokeCallback = function(id) {
   this._isPending[id] = true;
-  this._callbacks[id](this._pendingPayload);
+  this._callbacks[id].apply(this, this._pendingPayload);
   this._isHandled[id] = true;
 };
 
 /**
 * Set up bookkeeping needed when dispatching.
 *
-* @param {object} payload
+* @param {(string|object)} actionTypeOrPayload - actionType to invoke
+* or the payload object (for backwards compatability)
+* @param {Any} [payload]
 * @internal
 */
-MeteorFlux.Dispatcher.prototype._startDispatching = function(payload) {
+MeteorFlux.Dispatcher.prototype._startDispatching = function(/* arguments */) {
+
   for (var id in this._callbacks) {
     this._isPending[id] = false;
     this._isHandled[id] = false;
   }
-  this._pendingPayload = payload;
+  this._pendingPayload = arguments;
   this._isDispatching = true;
 };
 
@@ -175,45 +176,6 @@ MeteorFlux.Dispatcher.prototype._stopDispatching = function() {
 };
 
 
-/**
-* Curate the payload. If the user uses the first argument as string, use it
-* as action type and include it in the payload.
-*
-* @internal
-*/
-MeteorFlux.Dispatcher.prototype._curatePayload = function(/* arguments */) {
-  if (typeof arguments[0] === 'string') {
-    var action = arguments[1] || {};
-    action.type = arguments[0];
-    return action;
-  } else {
-    return arguments[0];
-  }
-};
-
-/**
-* Curate the payload. If the user uses the first argument as string, use it
-* as action type and include it in the payload.
-*
-* @internal
-*/
-MeteorFlux.Dispatcher.prototype._curateCallback = function(/* arguments */) {
-  if (typeof arguments[0] === 'string') {
-    var type = arguments[0];
-    var func = arguments[1];
-    return function(action) {
-      if (action.type === type)
-        func(action);
-    };
-  } else {
-    return arguments[0];
-  }
-};
-
-/**
-* Reset everything. Created for testing purposes
-*
-*/
 MeteorFlux.Dispatcher.prototype.reset = function() {
   this._callbacks = {};
   this._isPending = {};

--- a/packages/dispatcher/tests/dispatcher-tests.js
+++ b/packages/dispatcher/tests/dispatcher-tests.js
@@ -436,3 +436,28 @@ Tinytest.add('MeteorFlux - Dispatcher - It could be called with string as first 
 
     teardown();
 });
+
+Tinytest.add('MeteorFlux - Dispatcher - It could register with string as first argument', function (test) {
+    setup();
+
+    dispatcher.register('action', callbackA);
+    dispatcher.register('action2', callbackB);
+
+    var payload = {type: 'action'};
+    dispatcher.dispatch(payload);
+
+    test.equal(callbackA.calls.length, 1);
+    test.equal(callbackA.calls[0], payload);
+
+    test.equal(callbackB.calls.length, 0);
+
+    var payload_2 = { type: 'action2', data: 'data' };
+    dispatcher.dispatch(payload_2);
+
+    test.equal(callbackA.calls.length, 1);
+
+    test.equal(callbackB.calls.length, 1);
+    test.equal(callbackB.calls[0], payload_2);
+
+    teardown();
+});

--- a/packages/dispatcher/tests/dispatcher-tests.js
+++ b/packages/dispatcher/tests/dispatcher-tests.js
@@ -15,10 +15,38 @@ var mockCallback = function( name ) {
     return func;
 };
 
+var stringMockCallback = function(action, name) {
+    var name = name;
+    var action = action;
+
+    var funcs = {};
+    funcs[name] = {};
+    funcs[name][action] = [];
+
+    var func = function(action, payload ) {
+        if(funcs[name][action]) {
+            funcs[name][action].push(payload);
+        }
+    };
+
+    func.calls = funcs[name][action];
+    func.reset = function() {
+        this.calls = [];
+    };
+
+    return func;
+};
+
 var setup = function() {
     dispatcher = new MeteorFlux.Dispatcher();
     callbackA = mockCallback("A");
     callbackB = mockCallback("B");
+};
+
+var stringSetup = function() {
+    dispatcher = new MeteorFlux.Dispatcher();
+    callbackA = stringMockCallback("actionA", "A");
+    callbackB = stringMockCallback("actionB", "B");
 };
 
 var teardown = function() {
@@ -49,6 +77,28 @@ Tinytest.add('MeteorFlux - Tests - Test mock callback functions', function(test)
     teardown();
 });
 
+Tinytest.add('MeteorFlux - Tests - Test mock string callback functions', function(test) {
+    stringSetup();
+
+    test.equal( typeof callbackA, "function");
+    test.equal( typeof callbackA.calls, "object");
+
+    var payload = {};
+    callbackA("actionA", payload);
+    test.equal(callbackA.calls.length, 1);
+    test.equal(callbackA.calls[0], payload);
+
+    var payload_2 = {};
+    callbackA("actionA", payload_2);
+    test.equal(callbackA.calls.length, 2);
+    test.equal(callbackA.calls[1], payload_2);
+
+    callbackA.reset();
+    test.equal(callbackA.calls.length, 0);
+
+    teardown();
+});
+
 Tinytest.add('MeteorFlux - Dispatcher - It should be prototype of dispatcher', function (test) {
     setup();
 
@@ -57,7 +107,7 @@ Tinytest.add('MeteorFlux - Dispatcher - It should be prototype of dispatcher', f
     teardown();
 });
 
-Tinytest.add('MeteorFlux - Dispatcher - It should get reseted correctly', function (test) {
+Tinytest.add('MeteorFlux - Dispatcher - It should reset correctly', function (test) {
     setup();
 
     dispatcher._callbacks[0] = 1;
@@ -106,6 +156,39 @@ Tinytest.add('MeteorFlux - Dispatcher - It should execute all subscriber callbac
 
     test.equal(callbackB.calls.length, 2);
     test.equal(callbackB.calls[1], payload_2);
+
+    teardown();
+});
+
+Tinytest.add('MeteorFlux - Dispatcher - It should execute all subscriber callbacks -String call', function (test) {
+    stringSetup();
+
+    dispatcher.register(callbackA);
+    dispatcher.register(callbackB);
+
+    var payload = {};
+    dispatcher.dispatch('actionA', payload);
+
+    test.equal(callbackA.calls.length, 1);
+    test.equal(callbackA.calls[0], payload);
+
+    test.equal(callbackB.calls.length, 0);
+
+    var payload_2 = {};
+    dispatcher.dispatch('actionA', payload_2);
+
+    test.equal(callbackA.calls.length, 2);
+    test.equal(callbackA.calls[1], payload_2);
+
+    test.equal(callbackB.calls.length, 0);
+
+    var payload_3 = {};
+    dispatcher.dispatch('actionB', payload_3);
+
+    test.equal(callbackA.calls.length, 2);
+
+    test.equal(callbackB.calls.length, 1);
+    test.equal(callbackB.calls[0], payload_3);
 
     teardown();
 });
@@ -330,53 +413,24 @@ Tinytest.add('MeteorFlux - Dispatcher - It should properly unregister callbacks'
 
 
 Tinytest.add('MeteorFlux - Dispatcher - It could be called with string as first argument', function (test) {
-    setup();
+    stringSetup();
 
     dispatcher.register(callbackA);
     dispatcher.register(callbackB);
 
     var payload = {};
-    dispatcher.dispatch('action', payload);
+    dispatcher.dispatch('actionA', payload);
 
     test.equal(callbackA.calls.length, 1);
-    test.equal(callbackA.calls[0], payload);
-    test.equal(payload, { type: 'action' });
-
-    test.equal(callbackB.calls.length, 1);
-    test.equal(callbackB.calls[0], payload);
-
-    var payload_2 = { data: 'data' };
-    dispatcher.dispatch('action2', payload_2);
-
-    test.equal(callbackA.calls.length, 2);
-    test.equal(callbackA.calls[1], payload_2);
-    test.equal(payload_2, { data: 'data', type: 'action2' });
-
-    test.equal(callbackB.calls.length, 2);
-    test.equal(callbackB.calls[1], payload_2);
-
-    teardown();
-});
-
-Tinytest.add('MeteorFlux - Dispatcher - It could register with string as first argument', function (test) {
-    setup();
-
-    dispatcher.register('action', callbackA);
-    dispatcher.register('action2', callbackB);
-
-    var payload = {};
-    dispatcher.dispatch('action', payload);
-
-    test.equal(callbackA.calls.length, 1);
+    test.equal(callbackB.calls.length, 0);
     test.equal(callbackA.calls[0], payload);
 
     test.equal(callbackB.calls.length, 0);
 
     var payload_2 = { data: 'data' };
-    dispatcher.dispatch('action2', payload_2);
+    dispatcher.dispatch('actionB', payload_2);
 
     test.equal(callbackA.calls.length, 1);
-
     test.equal(callbackB.calls.length, 1);
     test.equal(callbackB.calls[0], payload_2);
 


### PR DESCRIPTION
When I created my Store package I wanted to be able to configure them the same way meteor helpers are set up, like so
```
{
  'action': function(param1, param2, etc) {
    return param1 + param2 + etc;
}
```
The way you implemented the "string callback" was to basically insert the string into the payload object, and then call the callbacks with the payload, unless the action had been registered by string (then you'd wrap the callback in a function). That didn't fit my use case so I took a more agnostic approach. I had made these changes needed a while ago, but never published them or made a pull request, so here we go. :)

In this implementation the dispatcher calls the registered stores with the same arguments that the dispatch got called, and it's up to the stores to read the dispatches. If it's called with the Classic™ way; `Dispatcher.dispath({type: 'actionType', data: 'data'})` then the stores' callbacks get called with the same object, just like it was. This implementation also lets the user call the dispatcher in a more 'Meteor-like' way using, `Dispatcher.dispatch('actionType', 'data')`, but also `Dispatcher.dispatch('actionType', 'data', 1, 2, 3, 'etc')`, and the callbacks get called with all the parameters. This is the same pattern that `Meteor.call`, and other Meteor methods use.

This lets stores to interpret the calls, and decide upon the way they want to get called. This made the `_curatePayload` function redundant, so I removed it. As I said the dispatcher can still be called with `Dispatcher.dispatch('actionType', {payload: data})` but the store callbacks are called with `callback('actionType', {payload: data})` (in stead of `callback({type: 'actionType', payload: data})`), so the `switch` look like this:

```
Dispatcher.register(function(/* arguments */){
  var actionType = arguments[0];
  var args = Array.prototype.slice.call(arguments, 1)
   switch( actionType ){
       case "SOMETHING_HAPPENED":
           doSomething.apply(this, args);
           break;
       case "OTHER_THING_HAPPENED":
           doOtherThing.apply(this, args);
           break;  
    }
});
```

These changes to have the side effect that both calls cannot be used at the same time (well, for the same actions), and if you registered with the "string way" the dispatch calls have to be made with a `payload` object.