### PR TITLE
more flexible implementation of filters

### DIFF
--- a/packages/dispatcher/lib/dispatcher.js
+++ b/packages/dispatcher/lib/dispatcher.js
@@ -118,7 +118,6 @@ MeteorFlux.Dispatcher.prototype.waitFor = function(ids) {
 */
 MeteorFlux.Dispatcher.prototype.dispatch = function(/* arguments */) {
   var payload = this._curatePayload.apply(this, arguments);
-  var dispatch = this._dispatch;
 
   var dispatchChain = this._dispatchFilters.reduceRight(function (next, filter) {
     return function (dispatch) {
@@ -156,7 +155,11 @@ MeteorFlux.Dispatcher.prototype._dispatch = function(payload) {
 * @param {function} callback
 */
 MeteorFlux.Dispatcher.prototype.addDispatchFilter = function(filter) {
-  this._dispatchFilters.push(filter(this._dispatch.bind(this)));
+  var dispatch = function(/* arguments */) {
+    this._dispatch(this._curatePayload.apply(this, arguments));
+  };
+
+  this._dispatchFilters.push(filter(dispatch.bind(this)));
 };
 
 /**

--- a/packages/dispatcher/lib/dispatcher.js
+++ b/packages/dispatcher/lib/dispatcher.js
@@ -48,12 +48,16 @@ MeteorFlux.Dispatcher = function(){
 * @return {string}
 */
 MeteorFlux.Dispatcher.prototype.register = function(/* arguments */) {
-  var callback = arguments;
-  for (var i = 0; i < this._registerFilters.length; i++) {
-    callback = this._registerFilters[i].apply(this, callback);
-  }
+  var callback = this._curateCallback.apply(this, arguments);
+
+  var callbackChain = this._registerFilters.reduceRight(function (next, filter) {
+    return function (payload) {
+      return filter(payload, next);
+    }
+  }, callback);
+
   var id = _prefix + _lastID++;
-  this._callbacks[id] = callback[0];
+  this._callbacks[id] = callbackChain;
   return id;
 };
 
@@ -113,18 +117,26 @@ MeteorFlux.Dispatcher.prototype.waitFor = function(ids) {
 * @param {object} payload
 */
 MeteorFlux.Dispatcher.prototype.dispatch = function(/* arguments */) {
+  var payload = this._curatePayload.apply(this, arguments);
+  var dispatch = this._dispatch;
+
+  var dispatchChain = this._dispatchFilters.reduceRight(function (next, filter) {
+    return function (dispatch) {
+      return filter(payload, next);
+    }
+  }, this._dispatch.bind(this));
+
+  dispatchChain(payload);
+};
+
+MeteorFlux.Dispatcher.prototype._dispatch = function(payload) {
   invariant(
     !this._isDispatching,
     'dispatcher-cant-dispatch-while-dispatching',
     'Dispatch.dispatch(...): Cannot dispatch in the middle of a dispatch.'
   );
-  var payload = arguments;
-  for (var i = 0; i < this._dispatchFilters.length; i++) {
-    payload = this._dispatchFilters[i].apply(this, payload);
-    if (payload === false) return;
-  }
 
-  this._startDispatching.apply(this, payload);
+  this._startDispatching(payload);
   try {
     for (var id in this._callbacks) {
       if (this._isPending[id]) {
@@ -144,7 +156,7 @@ MeteorFlux.Dispatcher.prototype.dispatch = function(/* arguments */) {
 * @param {function} callback
 */
 MeteorFlux.Dispatcher.prototype.addDispatchFilter = function(filter) {
-  this._dispatchFilters.push(filter);
+  this._dispatchFilters.push(filter(this._dispatch.bind(this)));
 };
 
 /**
@@ -175,7 +187,7 @@ MeteorFlux.Dispatcher.prototype.isDispatching = function() {
 */
 MeteorFlux.Dispatcher.prototype._invokeCallback = function(id) {
   this._isPending[id] = true;
-  this._callbacks[id].apply(this, this._pendingPayload);
+  this._callbacks[id](this._pendingPayload);
   this._isHandled[id] = true;
 };
 
@@ -185,13 +197,13 @@ MeteorFlux.Dispatcher.prototype._invokeCallback = function(id) {
 * @param {object} payload
 * @internal
 */
-MeteorFlux.Dispatcher.prototype._startDispatching = function(/* arguments */) {
+MeteorFlux.Dispatcher.prototype._startDispatching = function(payload) {
 
   for (var id in this._callbacks) {
     this._isPending[id] = false;
     this._isHandled[id] = false;
   }
-  this._pendingPayload = arguments;
+  this._pendingPayload = payload;
   this._isDispatching = true;
 };
 
@@ -215,9 +227,9 @@ MeteorFlux.Dispatcher.prototype._curatePayload = function(/* arguments */) {
   if (typeof arguments[0] === 'string') {
     var action = arguments[1] || {};
     action.type = arguments[0];
-    return [action];
+    return action;
   } else {
-    return arguments;
+    return arguments[0];
   }
 };
 
@@ -231,12 +243,12 @@ MeteorFlux.Dispatcher.prototype._curateCallback = function(/* arguments */) {
   if (typeof arguments[0] === 'string') {
     var type = arguments[0];
     var func = arguments[1];
-    return [function(action) {
+    return function(action) {
       if (action.type === type)
         func(action);
-    }];
+    };
   } else {
-    return arguments;
+    return arguments[0];
   }
 };
 
@@ -261,5 +273,3 @@ MeteorFlux.Dispatcher.prototype.reset = function() {
 */
 
 Dispatcher = new MeteorFlux.Dispatcher();
-Dispatcher.addDispatchFilter(Dispatcher._curatePayload);
-Dispatcher.addRegisterFilter(Dispatcher._curateCallback);

--- a/packages/dispatcher/tests/dispatcher-tests.js
+++ b/packages/dispatcher/tests/dispatcher-tests.js
@@ -23,8 +23,8 @@ var stringMockCallback = function(action, name) {
     funcs[name] = {};
     funcs[name][action] = [];
 
-    var func = function(action, payload ) {
-        if(funcs[name][action]) {
+    var func = function(payload) {
+        if (payload.type === action && funcs[name][action]) {
             funcs[name][action].push(payload);
         }
     };
@@ -39,8 +39,6 @@ var stringMockCallback = function(action, name) {
 
 var setup = function() {
     dispatcher = new MeteorFlux.Dispatcher();
-    dispatcher.addDispatchFilter(dispatcher._curatePayload);
-    dispatcher.addRegisterFilter(dispatcher._curateCallback);
     callbackA = mockCallback("A");
     callbackB = mockCallback("B");
 };
@@ -85,13 +83,13 @@ Tinytest.add('MeteorFlux - Tests - Test mock string callback functions', functio
     test.equal( typeof callbackA, "function");
     test.equal( typeof callbackA.calls, "object");
 
-    var payload = {};
-    callbackA("actionA", payload);
+    var payload = {type: 'actionA'};
+    callbackA(payload);
     test.equal(callbackA.calls.length, 1);
     test.equal(callbackA.calls[0], payload);
 
-    var payload_2 = {};
-    callbackA("actionA", payload_2);
+    var payload_2 = {type: 'actionA'};
+    callbackA(payload_2);
     test.equal(callbackA.calls.length, 2);
     test.equal(callbackA.calls[1], payload_2);
 
@@ -164,7 +162,6 @@ Tinytest.add('MeteorFlux - Dispatcher - It should execute all subscriber callbac
 
 Tinytest.add('MeteorFlux - Dispatcher - It should execute all subscriber callbacks -String call', function (test) {
     stringSetup();
-
 
     dispatcher.register(callbackA);
     dispatcher.register(callbackB);
@@ -469,23 +466,26 @@ Tinytest.add('MeteorFlux - Dispatcher - It could register with string as first a
     teardown();
 });
 
-Tinytest.add('MeteorFlux - Dispatcher - It should discard dipatches if a dispatch filter returns false', function (test) {
+Tinytest.add('MeteorFlux - Dispatcher - It should only dipatch if next is called in every dispatch filter', function (test) {
     setup();
 
     dispatcher.register('action', callbackA);
-    dispatcher.addDispatchFilter(function (payload) {
-        if (payload.skip === true) {
-            return false;
+    dispatcher.addDispatchFilter(function (dispatch) {
+        return function (payload, next) {
+            if (payload.skip !== true) {
+                next(payload);
+            }
         }
-        return [payload];
     });
 
-    dispatcher.addDispatchFilter(function (payload) {
-        if (payload.abort === true) {
-            return false;
+    dispatcher.addDispatchFilter(function (dispatch) {
+        return function (payload, next) {
+            if (payload.abort !== true) {
+                next(payload);
+            }
         }
-        return [payload];
-    })
+    });
+
     dispatcher.dispatch('action', { some: 'payload' });
     dispatcher.dispatch('action', { skip: true });
     dispatcher.dispatch('action', { abort: true });

--- a/packages/dispatcher/tests/dispatcher-tests.js
+++ b/packages/dispatcher/tests/dispatcher-tests.js
@@ -490,4 +490,32 @@ Tinytest.add('MeteorFlux - Dispatcher - It should only dipatch if next is called
     dispatcher.dispatch('action', { skip: true });
     dispatcher.dispatch('action', { abort: true });
     test.equal(callbackA.calls.length, 1);
+
+    teardown();
+});
+
+Tinytest.add('MeteorFlux - Dispatcher - Dispach filters can break the filter chain and dispatch prematurely', function (test) {
+    setup();
+
+    dispatcher.register('action', callbackA);
+    dispatcher.register('error', callbackB);
+
+    dispatcher.addDispatchFilter(function (dispatch) {
+        return function (payload, next) {
+            if (payload.error) {
+                dispatch('error', payload.error);
+            } else {
+                next(payload);
+            }
+        }
+    });
+
+    dispatcher.dispatch('action', { some: 'payload' });
+    test.equal(callbackA.calls.length, 1);
+
+    dispatcher.dispatch('action', { error: { message: 'test' }});
+    test.equal(callbackB.calls.length, 1);
+    test.equal(callbackA.calls.length, 1);
+
+    teardown();
 });


### PR DESCRIPTION
this is merely a suggestion on how to handle filters. I'm open to any input you may have on this. My implementation is inspired by redux. Filters would be defined like this:

``` javascript
Dispatcher.addDispatchFilter(dispatch => {
  return (payload, next) => {
    // do something
    next(payload);
  }
});
```

if `next` isn't called, the filter chain will not continue. At the end of the chain is the actual dispatch function which receives the resulting payload. It is also possible to interrupt the chain (by not calling `next`) and dispatching prematurely with the `dispatch` function passed to the filter. This is nice for handling errors for example or adding a logger.

I also included both of the `_curate` functions to the normal dispatch/register flow. This reduces the usage of `arguments` and is clearer imho.

What do you think?
